### PR TITLE
fix: use POST to append routes instead of PUT with index

### DIFF
--- a/backend/src/routes/caddyfile.js
+++ b/backend/src/routes/caddyfile.js
@@ -1,16 +1,15 @@
-import { exec, spawn } from 'child_process';
+import { exec } from 'child_process';
 import { Router } from 'express';
 import { createReadStream } from 'fs';
 import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { promisify } from 'util';
-import { caddyLoad } from '../caddy.js';
+import { caddyLoad, CADDY_ADMIN_URL } from '../caddy.js';
 
 const execAsync = promisify(exec);
 const router = Router();
 const CADDY_CONFIG_PATH = process.env.CADDY_CONFIG_PATH || '/etc/caddy/Caddyfile';
 const HISTORY_PATH = process.env.HISTORY_PATH || '/etc/caddy-ui/history';
-const CADDY_CONTAINER = process.env.CADDY_CONTAINER_NAME || 'caddy';
 const MAX_HISTORY = 20;
 
 async function ensureHistoryDir() {
@@ -45,39 +44,29 @@ async function pruneHistory() {
     } catch { }
 }
 
-function dockerExec(args, input) {
-    return new Promise((resolve, reject) => {
-        const proc = spawn('docker', ['exec', '-i', CADDY_CONTAINER, ...args]);
-        let stdout = '';
-        let stderr = '';
-        proc.stdout.on('data', d => { stdout += d; });
-        proc.stderr.on('data', d => { stderr += d; });
-        proc.on('close', code => {
-            if (code === 0) resolve({ stdout, stderr });
-            else reject(Object.assign(new Error(stderr.trim() || stdout.trim()), { stdout, stderr, code }));
-        });
-        proc.on('error', err => {
-            reject(Object.assign(err, { stdout, stderr: err.message, code: null }));
-        });
-        if (input) {
-            proc.stdin.write(input);
-            proc.stdin.end();
-        }
-    });
-}
-
 async function fmtCaddyfile(content) {
     try {
-        const { stdout } = await dockerExec(['caddy', 'fmt', '-'], content);
-        return stdout;
+        const { stdout } = await execAsync('caddy fmt -', { input: content });
+        return stdout || content;
     } catch (err) {
-        console.warn('caddy fmt failed:', err.message);
+        console.warn('caddy fmt failed, skipping:', err.message);
         return content;
     }
 }
 
 async function validateCaddyfile(content) {
-    await dockerExec(['caddy', 'validate', '--config', '-', '--adapter', 'caddyfile'], content);
+    const res = await fetch(`${CADDY_ADMIN_URL}/adapt?adapter=caddyfile`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/caddyfile', 'Origin': 'http://0.0.0.0:2019' },
+        body: content,
+    });
+    if (!res.ok) {
+        const text = await res.text();
+        const err = new Error(text);
+        err.stderr = text;
+        err.stdout = '';
+        throw err;
+    }
 }
 
 function parseSiteBlocks(content) {

--- a/backend/src/routes/routes.js
+++ b/backend/src/routes/routes.js
@@ -148,7 +148,12 @@ router.post('/', async (req, res) => {
     const route = buildReverseProxyRoute({ id, domain, upstream, stripPrefix });
 
     const routesPath = `/config/apps/http/servers/${PRIMARY_SERVER}/routes`;
-    await caddyPost(routesPath, route);
+    const existing = await caddyGet(routesPath).catch(() => null);
+    if (existing === null) {
+        await caddyPut(routesPath, [route]);
+    } else {
+        await caddyPost(routesPath, route);
+    }
 
     const caddyfile = await readFile(CADDY_CONFIG_PATH, 'utf8');
     const block = buildCaddyfileBlock({ domain, upstream, stripPrefix });

--- a/backend/src/routes/routes.js
+++ b/backend/src/routes/routes.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { readFile, writeFile } from 'fs/promises';
-import { caddyDelete, caddyGet, caddyPatch, caddyPut } from '../caddy.js';
+import { caddyDelete, caddyGet, caddyPatch, caddyPost, caddyPut } from '../caddy.js';
 
 const router = Router();
 
@@ -148,9 +148,7 @@ router.post('/', async (req, res) => {
     const route = buildReverseProxyRoute({ id, domain, upstream, stripPrefix });
 
     const routesPath = `/config/apps/http/servers/${PRIMARY_SERVER}/routes`;
-    const existing = await caddyGet(routesPath);
-    const index = existing.length;
-    await caddyPut(`${routesPath}/${index}`, route);
+    await caddyPost(routesPath, route);
 
     const caddyfile = await readFile(CADDY_CONFIG_PATH, 'utf8');
     const block = buildCaddyfileBlock({ domain, upstream, stripPrefix });


### PR DESCRIPTION
Fixes array index out of bounds error when adding routes to a Caddy server that already has existing routes. POST appends to the array without requiring a specific index position.

https://github.com/zackwag/caddy-ui/issues/13