### PR TITLE
fix: route caddy subprocess calls through docker exec, add structured logging

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine
 
+RUN apk add --no-cache docker-cli
+
 WORKDIR /app
 
 COPY package.json .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:20-alpine
 
-# Copy the Caddy binary from the official image for caddy fmt and version detection
-COPY --from=caddy:latest /usr/bin/caddy /usr/bin/caddy
-
 WORKDIR /app
 
 COPY package.json .

--- a/backend/src/caddy.js
+++ b/backend/src/caddy.js
@@ -1,3 +1,5 @@
+import logger from './logger.js';
+
 export const CADDY_ADMIN_URL = process.env.CADDY_ADMIN_URL || 'http://caddy:2019';
 
 const HEADERS = {
@@ -5,19 +7,52 @@ const HEADERS = {
     'Origin': 'http://0.0.0.0:2019',
 };
 
+const TIMEOUT_MS = 10000;
+
+function withTimeout(promise, ms, label) {
+    return Promise.race([
+        promise,
+        new Promise((_, reject) =>
+            setTimeout(() => reject(new Error(`Caddy API timeout after ${ms}ms: ${label}`)), ms)
+        ),
+    ]);
+}
+
 async function caddyRequest(method, path, body) {
-    const res = await fetch(`${CADDY_ADMIN_URL}${path}`, {
-        method,
-        headers: HEADERS,
-        body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
-    if (!res.ok) {
+    const url = `${CADDY_ADMIN_URL}${path}`;
+    const start = Date.now();
+    logger.debug(`Caddy API request`, { method, path });
+
+    try {
+        const res = await withTimeout(
+            fetch(url, {
+                method,
+                headers: HEADERS,
+                body: body !== undefined ? JSON.stringify(body) : undefined,
+            }),
+            TIMEOUT_MS,
+            `${method} ${path}`
+        );
+
+        const elapsed = Date.now() - start;
+
+        if (!res.ok) {
+            const text = await res.text();
+            logger.error(`Caddy API error`, { method, path, status: res.status, elapsed, body: text.slice(0, 200) });
+            throw new Error(`Caddy API error: ${res.status} ${text}`);
+        }
+
+        logger.debug(`Caddy API response`, { method, path, status: res.status, elapsed });
         const text = await res.text();
-        throw new Error(`Caddy API error: ${res.status} ${text}`);
+        if (!text) return null;
+        try { return JSON.parse(text); } catch { return text; }
+    } catch (err) {
+        const elapsed = Date.now() - start;
+        if (!err.message.includes('Caddy API error')) {
+            logger.error(`Caddy API failed`, { method, path, elapsed, error: err.message });
+        }
+        throw err;
     }
-    const text = await res.text();
-    if (!text) return null;
-    try { return JSON.parse(text); } catch { return text; }
 }
 
 export const caddyGet = (path) => caddyRequest('GET', path);
@@ -27,13 +62,35 @@ export const caddyPatch = (path, body) => caddyRequest('PATCH', path, body);
 export const caddyDelete = (path) => caddyRequest('DELETE', path);
 
 export async function caddyLoad(caddyfileContent) {
-    const res = await fetch(`${CADDY_ADMIN_URL}/load`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'text/caddyfile', 'Origin': 'http://0.0.0.0:2019' },
-        body: caddyfileContent,
-    });
-    if (!res.ok) {
-        const text = await res.text();
-        throw new Error(`Caddy reload failed: ${text}`);
+    const url = `${CADDY_ADMIN_URL}/load`;
+    const start = Date.now();
+    logger.info(`Caddy reload initiated`);
+
+    try {
+        const res = await withTimeout(
+            fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'text/caddyfile', 'Origin': 'http://0.0.0.0:2019' },
+                body: caddyfileContent,
+            }),
+            TIMEOUT_MS,
+            'POST /load'
+        );
+
+        const elapsed = Date.now() - start;
+
+        if (!res.ok) {
+            const text = await res.text();
+            logger.error(`Caddy reload failed`, { status: res.status, elapsed, body: text.slice(0, 200) });
+            throw new Error(`Caddy reload failed: ${text}`);
+        }
+
+        logger.info(`Caddy reload complete`, { elapsed });
+    } catch (err) {
+        const elapsed = Date.now() - start;
+        if (!err.message.includes('Caddy reload failed')) {
+            logger.error(`Caddy reload error`, { elapsed, error: err.message });
+        }
+        throw err;
     }
 }

--- a/backend/src/docker.js
+++ b/backend/src/docker.js
@@ -1,0 +1,24 @@
+import { spawn } from 'child_process';
+
+export const CADDY_CONTAINER = process.env.CADDY_CONTAINER_NAME || 'caddy';
+
+export function dockerExec(args, input) {
+    return new Promise((resolve, reject) => {
+        const proc = spawn('docker', ['exec', '-i', CADDY_CONTAINER, ...args]);
+        let stdout = '';
+        let stderr = '';
+        proc.stdout.on('data', d => { stdout += d; });
+        proc.stderr.on('data', d => { stderr += d; });
+        proc.on('close', code => {
+            if (code === 0) resolve({ stdout, stderr });
+            else reject(Object.assign(new Error(stderr.trim() || stdout.trim()), { stdout, stderr, code }));
+        });
+        proc.on('error', err => {
+            reject(Object.assign(err, { stdout, stderr: err.message, code: null }));
+        });
+        if (input) {
+            proc.stdin.write(input);
+            proc.stdin.end();
+        }
+    });
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ import cors from 'cors';
 import express from 'express';
 import 'express-async-errors';
 
+import logger from './logger.js';
 import { authMiddleware, publicMetrics } from './middleware/auth.js';
 import authRouter from './routes/auth.js';
 import caddyfileRouter from './routes/caddyfile.js';
@@ -21,6 +22,20 @@ const CADDY_ADMIN_URL = process.env.CADDY_ADMIN_URL || 'http://caddy:2019';
 app.use(cors());
 app.use(express.json());
 app.use(express.text({ type: 'text/plain' }));
+
+app.use((req, res, next) => {
+    const start = Date.now();
+    res.on('finish', () => {
+        const elapsed = Date.now() - start;
+        const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'info';
+        logger[level](`${req.method} ${req.path}`, {
+            status: res.statusCode,
+            elapsed,
+            ip: req.ip,
+        });
+    });
+    next();
+});
 
 // Auth routes are always public
 app.use('/api/auth', authRouter);
@@ -55,13 +70,13 @@ app.use('/api/health', healthRouter);
 app.use('/api/route-notes', routenotesRouter);
 
 app.use((err, req, res, next) => {
-    console.error(err);
+    logger.error(`Unhandled error`, { method: req.method, path: req.path, error: err.message, stack: err.stack });
     res.status(500).json({ error: err.message || 'Internal server error' });
 });
 
 app.listen(PORT, () => {
-    console.log(`Caddy UI backend running on port ${PORT}`);
-    console.log(`Caddy admin API: ${CADDY_ADMIN_URL}`);
-    console.log(`Caddyfile path: ${process.env.CADDY_CONFIG_PATH || '/etc/caddy/Caddyfile'}`);
-    console.log(`Public metrics: ${publicMetrics}`);
+    logger.info(`Caddy UI backend running`, { port: PORT });
+    logger.info(`Caddy admin API`, { url: CADDY_ADMIN_URL });
+    logger.info(`Caddyfile path`, { path: process.env.CADDY_CONFIG_PATH || '/etc/caddy/Caddyfile' });
+    logger.info(`Public metrics`, { enabled: publicMetrics });
 });

--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -1,10 +1,13 @@
 const isDev = process.env.NODE_ENV !== 'production';
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
+const minLevel = LEVELS[process.env.LOG_LEVEL?.toLowerCase()] ?? 1;
 
 function timestamp() {
     return new Date().toISOString();
 }
 
 function log(level, message, meta = {}) {
+    if (LEVELS[level] < minLevel) return;
     const entry = { ts: timestamp(), level, message, ...meta };
     if (isDev) {
         const metaStr = Object.keys(meta).length ? ' ' + JSON.stringify(meta) : '';

--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -1,0 +1,24 @@
+const isDev = process.env.NODE_ENV !== 'production';
+
+function timestamp() {
+    return new Date().toISOString();
+}
+
+function log(level, message, meta = {}) {
+    const entry = { ts: timestamp(), level, message, ...meta };
+    if (isDev) {
+        const metaStr = Object.keys(meta).length ? ' ' + JSON.stringify(meta) : '';
+        console.log(`[${entry.ts}] ${level.toUpperCase().padEnd(5)} ${message}${metaStr}`);
+    } else {
+        console.log(JSON.stringify(entry));
+    }
+}
+
+export const logger = {
+    info: (message, meta) => log('info', message, meta),
+    warn: (message, meta) => log('warn', message, meta),
+    error: (message, meta) => log('error', message, meta),
+    debug: (message, meta) => log('debug', message, meta),
+};
+
+export default logger;

--- a/backend/src/routes/caddyfile.js
+++ b/backend/src/routes/caddyfile.js
@@ -1,15 +1,14 @@
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 import { Router } from 'express';
 import { createReadStream } from 'fs';
 import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises';
 import { join } from 'path';
-import { promisify } from 'util';
 import { CADDY_ADMIN_URL, caddyLoad } from '../caddy.js';
 
-const execAsync = promisify(exec);
 const router = Router();
 const CADDY_CONFIG_PATH = process.env.CADDY_CONFIG_PATH || '/etc/caddy/Caddyfile';
 const HISTORY_PATH = process.env.HISTORY_PATH || '/etc/caddy-ui/history';
+const CADDY_CONTAINER = process.env.CADDY_CONTAINER_NAME || 'caddy';
 const MAX_HISTORY = 20;
 
 async function ensureHistoryDir() {
@@ -44,12 +43,33 @@ async function pruneHistory() {
     } catch { }
 }
 
+function dockerExec(args, input) {
+    return new Promise((resolve, reject) => {
+        const proc = spawn('docker', ['exec', '-i', CADDY_CONTAINER, ...args]);
+        let stdout = '';
+        let stderr = '';
+        proc.stdout.on('data', d => { stdout += d; });
+        proc.stderr.on('data', d => { stderr += d; });
+        proc.on('close', code => {
+            if (code === 0) resolve({ stdout, stderr });
+            else reject(Object.assign(new Error(stderr.trim() || stdout.trim()), { stdout, stderr, code }));
+        });
+        proc.on('error', err => {
+            reject(Object.assign(err, { stdout, stderr: err.message, code: null }));
+        });
+        if (input) {
+            proc.stdin.write(input);
+            proc.stdin.end();
+        }
+    });
+}
+
 async function fmtCaddyfile(content) {
     try {
-        const { stdout } = await execAsync('caddy fmt -', { input: content });
+        const { stdout } = await dockerExec(['caddy', 'fmt', '-'], content);
         return stdout || content;
-    } catch {
-        // caddy binary not available in this environment -- skip formatting
+    } catch (err) {
+        console.warn('caddy fmt failed:', err.message);
         return content;
     }
 }
@@ -215,7 +235,9 @@ router.post('/validations', async (req, res) => {
     }
     try {
         await validateCaddyfile(content);
-        res.json({ valid: true, warnings: [] });
+        const fmt = req.query.fmt !== 'false' && req.query.fmt === 'true';
+        const formatted = fmt ? await fmtCaddyfile(content) : null;
+        res.json({ valid: true, warnings: [], ...(formatted ? { formatted } : {}) });
     } catch (err) {
         const output = ((err.stdout || '') + (err.stderr || '')).trim();
         const lines = output.split('\n').filter(Boolean);

--- a/backend/src/routes/caddyfile.js
+++ b/backend/src/routes/caddyfile.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { createReadStream } from 'fs';
-import { readdir, readFile, unlink, writeFile } from 'fs/promises';
+import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { CADDY_ADMIN_URL, caddyLoad } from '../caddy.js';
 import { dockerExec } from '../docker.js';
@@ -10,6 +10,39 @@ const router = Router();
 const CADDY_CONFIG_PATH = process.env.CADDY_CONFIG_PATH || '/etc/caddy/Caddyfile';
 const HISTORY_PATH = process.env.HISTORY_PATH || '/etc/caddy-ui/history';
 const MAX_HISTORY = 20;
+
+async function ensureHistoryDir() {
+    try {
+        await mkdir(HISTORY_PATH, { recursive: true });
+    } catch { }
+}
+
+async function snapshotCaddyfile() {
+    try {
+        await ensureHistoryDir();
+        const content = await readFile(CADDY_CONFIG_PATH, 'utf8');
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const filename = `Caddyfile-${timestamp}`;
+        await writeFile(join(HISTORY_PATH, filename), content, 'utf8');
+        await pruneHistory();
+        logger.info(`Caddyfile snapshot created`, { filename });
+    } catch (err) {
+        logger.warn(`Failed to snapshot Caddyfile`, { error: err.message });
+    }
+}
+
+async function pruneHistory() {
+    try {
+        const files = await readdir(HISTORY_PATH);
+        const sorted = files
+            .filter(f => f.startsWith('Caddyfile-'))
+            .sort()
+            .reverse();
+        for (const file of sorted.slice(MAX_HISTORY)) {
+            await unlink(join(HISTORY_PATH, file)).catch(() => { });
+        }
+    } catch { }
+}
 
 async function fmtCaddyfile(content) {
     try {

--- a/backend/src/routes/caddyfile.js
+++ b/backend/src/routes/caddyfile.js
@@ -1,75 +1,22 @@
-import { spawn } from 'child_process';
 import { Router } from 'express';
 import { createReadStream } from 'fs';
-import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises';
+import { readdir, readFile, unlink, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { CADDY_ADMIN_URL, caddyLoad } from '../caddy.js';
+import { dockerExec } from '../docker.js';
+import logger from '../logger.js';
 
 const router = Router();
 const CADDY_CONFIG_PATH = process.env.CADDY_CONFIG_PATH || '/etc/caddy/Caddyfile';
 const HISTORY_PATH = process.env.HISTORY_PATH || '/etc/caddy-ui/history';
-const CADDY_CONTAINER = process.env.CADDY_CONTAINER_NAME || 'caddy';
 const MAX_HISTORY = 20;
-
-async function ensureHistoryDir() {
-    try {
-        await mkdir(HISTORY_PATH, { recursive: true });
-    } catch { }
-}
-
-async function snapshotCaddyfile() {
-    try {
-        await ensureHistoryDir();
-        const content = await readFile(CADDY_CONFIG_PATH, 'utf8');
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-        const filename = `Caddyfile-${timestamp}`;
-        await writeFile(join(HISTORY_PATH, filename), content, 'utf8');
-        await pruneHistory();
-    } catch (err) {
-        console.warn('Failed to snapshot Caddyfile:', err.message);
-    }
-}
-
-async function pruneHistory() {
-    try {
-        const files = await readdir(HISTORY_PATH);
-        const sorted = files
-            .filter(f => f.startsWith('Caddyfile-'))
-            .sort()
-            .reverse();
-        for (const file of sorted.slice(MAX_HISTORY)) {
-            await unlink(join(HISTORY_PATH, file)).catch(() => { });
-        }
-    } catch { }
-}
-
-function dockerExec(args, input) {
-    return new Promise((resolve, reject) => {
-        const proc = spawn('docker', ['exec', '-i', CADDY_CONTAINER, ...args]);
-        let stdout = '';
-        let stderr = '';
-        proc.stdout.on('data', d => { stdout += d; });
-        proc.stderr.on('data', d => { stderr += d; });
-        proc.on('close', code => {
-            if (code === 0) resolve({ stdout, stderr });
-            else reject(Object.assign(new Error(stderr.trim() || stdout.trim()), { stdout, stderr, code }));
-        });
-        proc.on('error', err => {
-            reject(Object.assign(err, { stdout, stderr: err.message, code: null }));
-        });
-        if (input) {
-            proc.stdin.write(input);
-            proc.stdin.end();
-        }
-    });
-}
 
 async function fmtCaddyfile(content) {
     try {
         const { stdout } = await dockerExec(['caddy', 'fmt', '-'], content);
         return stdout || content;
     } catch (err) {
-        console.warn('caddy fmt failed:', err.message);
+        logger.warn('caddy fmt failed', { error: err.message });
         return content;
     }
 }
@@ -233,22 +180,39 @@ router.post('/validations', async (req, res) => {
     if (!content || typeof content !== 'string') {
         return res.status(400).json({ error: 'Body must be plain text Caddyfile content' });
     }
+
+    const fmt = req.query.fmt === 'true';
+    logger.info(`Validating Caddyfile`, { bytes: content.length, fmt });
+
     try {
         await validateCaddyfile(content);
-        const fmt = req.query.fmt !== 'false' && req.query.fmt === 'true';
-        const formatted = fmt ? await fmtCaddyfile(content) : null;
-        res.json({ valid: true, warnings: [], ...(formatted ? { formatted } : {}) });
+        logger.info(`Caddyfile adapt validation passed`);
     } catch (err) {
         const output = ((err.stdout || '') + (err.stderr || '')).trim();
         const lines = output.split('\n').filter(Boolean);
         const warnings = lines.filter(l => l.toLowerCase().includes('warn'));
         const errors = lines.filter(l => l.toLowerCase().includes('error'));
-        res.status(422).json({ valid: false, errors: errors.length ? errors : [err.message], warnings });
+        logger.warn(`Caddyfile adapt validation failed`, { errors });
+        return res.status(422).json({ valid: false, errors: errors.length ? errors : [err.message], warnings });
     }
+
+    let formatted = null;
+    if (fmt) {
+        try {
+            formatted = await fmtCaddyfile(content);
+            logger.info(`Caddyfile fmt passed`);
+        } catch (err) {
+            logger.warn(`Caddyfile fmt failed`, { error: err.message });
+            return res.status(422).json({ valid: false, errors: [`caddy fmt failed: ${err.message}`], warnings: [] });
+        }
+    }
+
+    res.json({ valid: true, warnings: [], ...(formatted ? { formatted } : {}) });
 });
 
 // POST /api/caddyfile/reloads
 router.post('/reloads', async (req, res) => {
+    logger.info(`Caddyfile reload requested`);
     const content = await readFile(CADDY_CONFIG_PATH, 'utf8');
     await caddyLoad(content);
     res.json({ ok: true, message: 'Caddy reloaded from disk' });
@@ -263,24 +227,39 @@ router.put('/', async (req, res) => {
 
     const fmt = req.query.fmt !== 'false';
     const sort = req.query.sort !== 'false';
+    logger.info(`Saving Caddyfile`, { bytes: content.length, fmt, sort });
 
     try {
         await validateCaddyfile(content);
+        logger.info(`Caddyfile pre-save validation passed`);
     } catch (err) {
         const output = ((err.stdout || '') + (err.stderr || '')).trim();
         const lines = output.split('\n').filter(Boolean);
         const errors = lines.filter(l => l.toLowerCase().includes('error'));
+        logger.warn(`Caddyfile pre-save validation failed`, { errors });
         return res.status(422).json({ valid: false, errors: errors.length ? errors : [err.message] });
     }
 
     await snapshotCaddyfile();
-    await caddyLoad(content);
 
     let final = content;
-    if (fmt) final = await fmtCaddyfile(final);
-    if (sort) final = sortCaddyfile(final);
+    if (fmt) {
+        try {
+            final = await fmtCaddyfile(final);
+            logger.info(`Caddyfile formatted`);
+        } catch (err) {
+            logger.warn(`caddy fmt failed`, { error: err.message });
+            return res.status(422).json({ valid: false, errors: [`caddy fmt failed: ${err.message}`] });
+        }
+    }
+    if (sort) {
+        final = sortCaddyfile(final);
+        logger.info(`Caddyfile sorted`);
+    }
 
+    await caddyLoad(final);
     await writeFile(CADDY_CONFIG_PATH, final, 'utf8');
+    logger.info(`Caddyfile saved`, { bytes: final.length });
     res.json({ ok: true, message: 'Caddyfile saved and reloaded' });
 });
 

--- a/backend/src/routes/logs.js
+++ b/backend/src/routes/logs.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { createReadStream, unwatchFile, watchFile } from 'fs';
 import { readFile, stat, writeFile } from 'fs/promises';
 import { CADDY_ADMIN_URL, caddyLoad } from '../caddy.js';
+import logger from '../logger.js';
 const router = Router();
 const LOG_PATH = process.env.CADDY_LOG_PATH || '/var/log/caddy/access.log';
 const CADDY_CONFIG_PATH = process.env.CADDY_CONFIG_PATH || '/etc/caddy/Caddyfile';
@@ -129,10 +130,10 @@ router.put('/config', async (req, res) => {
         return res.status(400).json({ error: 'Invalid log config' });
     }
 
+    logger.info(`Log config update requested`, { enabled: config.enabled });
     const content = await readFile(CADDY_CONFIG_PATH, 'utf8');
     const updated = updateGlobalBlock(content, config);
 
-    // Validate before writing
     try {
         const validateRes = await fetch(`${CADDY_ADMIN_URL}/adapt?adapter=caddyfile`, {
             method: 'POST',
@@ -143,15 +144,17 @@ router.put('/config', async (req, res) => {
             const text = await validateRes.text();
             const lines = text.split('\n').filter(Boolean);
             const errors = lines.filter(l => l.toLowerCase().includes('error'));
+            logger.warn(`Log config validation failed`, { errors });
             return res.status(422).json({ errors: errors.length ? errors : lines });
         }
     } catch (err) {
+        logger.error(`Log config validation error`, { error: err.message });
         return res.status(422).json({ errors: [err.message] });
     }
 
     await writeFile(CADDY_CONFIG_PATH, updated, 'utf8');
     await caddyLoad(updated);
-
+    logger.info(`Log config saved and reloaded`);
     res.json({ ok: true, message: 'Log config saved and reloaded' });
 });
 

--- a/backend/src/routes/metrics.js
+++ b/backend/src/routes/metrics.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { readFile, writeFile } from 'fs/promises';
 import { CADDY_ADMIN_URL, caddyLoad } from '../caddy.js';
+import logger from '../logger.js';
 
 const router = Router();
 
@@ -129,8 +130,10 @@ router.put('/config', async (req, res) => {
         } else {
             content = content.replace(/^\s*metrics\s*\n?/m, '');
         }
+        logger.info(`Metrics config update requested`, { enabled });
         await writeFile(CADDY_CONFIG_PATH, content, 'utf8');
         await caddyLoad(content);
+        logger.info(`Metrics config saved and reloaded`, { enabled });
         res.json({ ok: true, enabled });
     } catch (err) {
         res.status(500).json({ error: err.message });

--- a/backend/src/routes/routes.js
+++ b/backend/src/routes/routes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { readFile, writeFile } from 'fs/promises';
 import { caddyDelete, caddyGet, caddyPatch, caddyPost, caddyPut } from '../caddy.js';
+import logger from '../logger.js';
 
 const router = Router();
 
@@ -143,6 +144,7 @@ router.post('/', async (req, res) => {
     if (!domain || !upstream) {
         return res.status(400).json({ error: 'domain and upstream are required' });
     }
+    logger.info(`Adding route`, { domain, upstream, stripPrefix });
 
     const id = `route-${Date.now()}`;
     const route = buildReverseProxyRoute({ id, domain, upstream, stripPrefix });
@@ -159,6 +161,7 @@ router.post('/', async (req, res) => {
     const block = buildCaddyfileBlock({ domain, upstream, stripPrefix });
     await writeFile(CADDY_CONFIG_PATH, `${caddyfile.trimEnd()}\n\n${block}\n`, 'utf8');
 
+    logger.info(`Route added`, { id, domain, upstream });
     res.status(201).json({ ok: true, id, route });
 });
 
@@ -169,14 +172,14 @@ router.patch('/:id', async (req, res) => {
     if (!domain || !upstream) {
         return res.status(400).json({ error: 'domain and upstream are required' });
     }
+    logger.info(`Updating route`, { id, domain, upstream });
 
-    // Get old route to find old domain for Caddyfile update
     let oldDomain = null;
     try {
         const oldRoute = await caddyGet(`/id/${id}`);
         oldDomain = oldRoute?.match?.[0]?.host?.[0] || null;
     } catch {
-        // Continue anyway
+        logger.warn(`Could not fetch old route for update`, { id });
     }
 
     const route = buildReverseProxyRoute({ id, domain, upstream, stripPrefix });
@@ -190,6 +193,7 @@ router.patch('/:id', async (req, res) => {
         await writeFile(CADDY_CONFIG_PATH, updated, 'utf8');
     }
 
+    logger.info(`Route updated`, { id, domain, upstream });
     res.json({ ok: true, id, route });
 });
 
@@ -216,13 +220,14 @@ router.patch('/caddyfile/:domain', async (req, res) => {
 // DELETE /api/routes/:id
 router.delete('/:id', async (req, res) => {
     const { id } = req.params;
+    logger.info(`Deleting route`, { id });
 
     let domain = null;
     try {
         const route = await caddyGet(`/id/${id}`);
         domain = route?.match?.[0]?.host?.[0] || null;
     } catch {
-        // Route may already be gone
+        logger.warn(`Could not fetch route for deletion`, { id });
     }
 
     await caddyDelete(`/id/${id}`);
@@ -233,6 +238,7 @@ router.delete('/:id', async (req, res) => {
         await writeFile(CADDY_CONFIG_PATH, cleaned, 'utf8');
     }
 
+    logger.info(`Route deleted`, { id, domain });
     res.json({ ok: true, id });
 });
 

--- a/backend/src/routes/status.js
+++ b/backend/src/routes/status.js
@@ -1,16 +1,18 @@
-import { exec } from 'child_process';
 import { Router } from 'express';
-import { promisify } from 'util';
 import { CADDY_ADMIN_URL, caddyGet } from '../caddy.js';
+import { dockerExec } from '../docker.js';
+import logger from '../logger.js';
 
 const router = Router();
-const execAsync = promisify(exec);
 
 async function getCaddyVersion() {
     try {
-        const { stdout } = await execAsync('caddy version');
-        return stdout.trim().split(' ')[0] || 'unknown';
-    } catch {
+        const { stdout } = await dockerExec(['caddy', 'version']);
+        const version = stdout.trim().split(' ')[0] || 'unknown';
+        logger.debug(`Caddy version detected`, { version });
+        return version;
+    } catch (err) {
+        logger.warn(`Could not detect Caddy version`, { error: err.message });
         return 'unknown';
     }
 }

--- a/backend/src/routes/tls.js
+++ b/backend/src/routes/tls.js
@@ -13,12 +13,7 @@ async function parseCert(certPath) {
     try {
         const pem = await readFile(certPath, 'utf8');
         const cert = new X509Certificate(pem);
-        return {
-            validFrom: cert.validFrom,
-            validTo: cert.validTo,
-            subject: cert.subject,
-            issuer: cert.issuer,
-        };
+        return { validFrom: cert.validFrom, validTo: cert.validTo, subject: cert.subject, issuer: cert.issuer };
     } catch {
         return null;
     }
@@ -29,9 +24,7 @@ async function getManagedDomains() {
         const tls = await caddyGet('/config/apps/tls');
         const domains = new Set();
         for (const policy of tls?.automation?.policies || []) {
-            for (const subject of policy.subjects || []) {
-                domains.add(subject);
-            }
+            for (const subject of policy.subjects || []) domains.add(subject);
         }
         return domains;
     } catch {
@@ -73,32 +66,25 @@ async function getCerts() {
             const isManaged = managedDomains.has(domain);
 
             let status;
-            if (!isManaged) {
-                status = 'orphaned';
-            } else if (daysRemaining < 0) {
-                status = isInternal ? 'valid' : 'expired';
-            } else if (daysRemaining < 14 && !isInternal) {
-                status = 'expiring';
-            } else {
-                status = 'valid';
-            }
+            if (!isManaged) status = 'orphaned';
+            else if (daysRemaining < 0) status = isInternal ? 'valid' : 'expired';
+            else if (daysRemaining < 14 && !isInternal) status = 'expiring';
+            else status = 'valid';
 
-            results.push({
-                domain,
-                issuer: isInternal ? 'internal' : 'acme',
-                issuerDir: issuer,
-                validFrom: info.validFrom,
-                validTo: info.validTo,
-                daysRemaining,
-                isManaged,
-                isInternal,
-                status,
-            });
+            results.push({ domain, issuer: isInternal ? 'internal' : 'acme', issuerDir: issuer, validFrom: info.validFrom, validTo: info.validTo, daysRemaining, isManaged, isInternal, status });
+        }
+    }
+
+    // Mark internal certs as superseded when the same domain also has an ACME cert
+    const acmeDomains = new Set(results.filter(c => !c.isInternal).map(c => c.domain));
+    for (const cert of results) {
+        if (cert.isInternal && acmeDomains.has(cert.domain)) {
+            cert.status = 'superseded';
         }
     }
 
     return results.sort((a, b) => {
-        const order = { orphaned: 0, expired: 1, expiring: 2, valid: 3 };
+        const order = { orphaned: 0, superseded: 1, expired: 2, expiring: 3, valid: 4 };
         if (order[a.status] !== order[b.status]) return order[a.status] - order[b.status];
         return a.daysRemaining - b.daysRemaining;
     });
@@ -111,7 +97,7 @@ router.get('/', async (req, res) => {
     res.json(certs);
 });
 
-// DELETE /api/tls/:domain -- only allowed for orphaned certs
+// DELETE /api/tls/:domain
 router.delete('/:domain', async (req, res) => {
     const { domain } = req.params;
     logger.info(`TLS cert deletion requested`, { domain });
@@ -120,28 +106,20 @@ router.delete('/:domain', async (req, res) => {
         return res.status(400).json({ error: 'Invalid domain' });
     }
 
-    const managedDomains = await getManagedDomains();
-    if (managedDomains.has(domain)) {
-        logger.warn(`Refused to delete managed cert`, { domain });
-        return res.status(403).json({ error: 'Cannot delete a cert for an actively managed domain' });
+    const certs = await getCerts();
+    const internalCert = certs.find(c => c.domain === domain && c.isInternal);
+    const acmeCert = certs.find(c => c.domain === domain && !c.isInternal);
+
+    const canDeleteInternal = internalCert && ['orphaned', 'superseded', 'expired'].includes(internalCert.status);
+    const canDeleteAcme = acmeCert && acmeCert.status === 'orphaned';
+
+    if (!canDeleteInternal && !canDeleteAcme) {
+        logger.warn(`Refused to delete cert`, { domain });
+        return res.status(403).json({ error: 'Cannot delete this cert — only orphaned, superseded, or expired internal certs can be removed' });
     }
 
-    let certDir = null;
-    try {
-        const issuers = await readdir(CERTS_PATH);
-        for (const issuer of issuers) {
-            const candidate = join(CERTS_PATH, issuer, domain);
-            try { await readdir(candidate); certDir = candidate; break; } catch { }
-        }
-    } catch (err) {
-        logger.error(`Failed to scan certs`, { domain, error: err.message });
-        return res.status(500).json({ error: `Failed to scan certs: ${err.message}` });
-    }
-
-    if (!certDir) {
-        logger.warn(`Cert not found`, { domain });
-        return res.status(404).json({ error: `Cert not found for domain: ${domain}` });
-    }
+    const target = canDeleteInternal ? internalCert : acmeCert;
+    const certDir = join(CERTS_PATH, target.issuerDir, domain);
 
     try {
         await rm(certDir, { recursive: true, force: true });
@@ -153,7 +131,7 @@ router.delete('/:domain', async (req, res) => {
     }
 });
 
-// GET /api/tls/ca -- download Caddy's root CA cert via admin API
+// GET /api/tls/ca
 router.get('/ca', async (req, res) => {
     logger.info(`Root CA download requested`);
     try {

--- a/backend/src/routes/tls.js
+++ b/backend/src/routes/tls.js
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { readdir, readFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { CADDY_ADMIN_URL, caddyGet } from '../caddy.js';
+import logger from '../logger.js';
 
 const router = Router();
 const CADDY_DATA_PATH = process.env.CADDY_DATA_PATH || '/data/caddy/caddy';
@@ -46,6 +47,7 @@ async function getCerts() {
     try {
         issuers = await readdir(CERTS_PATH);
     } catch {
+        logger.warn(`Could not read certs path`, { path: CERTS_PATH });
         return [];
     }
 
@@ -105,12 +107,14 @@ async function getCerts() {
 // GET /api/tls
 router.get('/', async (req, res) => {
     const certs = await getCerts();
+    logger.info(`TLS certs listed`, { count: certs.length });
     res.json(certs);
 });
 
 // DELETE /api/tls/:domain -- only allowed for orphaned certs
 router.delete('/:domain', async (req, res) => {
     const { domain } = req.params;
+    logger.info(`TLS cert deletion requested`, { domain });
 
     if (domain.includes('..') || domain.includes('/')) {
         return res.status(400).json({ error: 'Invalid domain' });
@@ -118,39 +122,40 @@ router.delete('/:domain', async (req, res) => {
 
     const managedDomains = await getManagedDomains();
     if (managedDomains.has(domain)) {
+        logger.warn(`Refused to delete managed cert`, { domain });
         return res.status(403).json({ error: 'Cannot delete a cert for an actively managed domain' });
     }
 
-    // Find the issuer directory by scanning the filesystem
     let certDir = null;
     try {
         const issuers = await readdir(CERTS_PATH);
         for (const issuer of issuers) {
             const candidate = join(CERTS_PATH, issuer, domain);
-            try {
-                await readdir(candidate);
-                certDir = candidate;
-                break;
-            } catch { }
+            try { await readdir(candidate); certDir = candidate; break; } catch { }
         }
     } catch (err) {
+        logger.error(`Failed to scan certs`, { domain, error: err.message });
         return res.status(500).json({ error: `Failed to scan certs: ${err.message}` });
     }
 
     if (!certDir) {
+        logger.warn(`Cert not found`, { domain });
         return res.status(404).json({ error: `Cert not found for domain: ${domain}` });
     }
 
     try {
         await rm(certDir, { recursive: true, force: true });
+        logger.info(`TLS cert deleted`, { domain, certDir });
         res.json({ ok: true, message: `Deleted cert for ${domain}` });
     } catch (err) {
+        logger.error(`Failed to delete cert`, { domain, error: err.message });
         res.status(500).json({ error: `Failed to delete cert: ${err.message}` });
     }
 });
 
 // GET /api/tls/ca -- download Caddy's root CA cert via admin API
 router.get('/ca', async (req, res) => {
+    logger.info(`Root CA download requested`);
     try {
         const caRes = await fetch(`${CADDY_ADMIN_URL}/pki/ca/local`, {
             headers: { 'Origin': 'http://0.0.0.0:2019' },
@@ -159,10 +164,12 @@ router.get('/ca', async (req, res) => {
         const data = await caRes.json();
         const pem = data.root_certificate;
         if (!pem) throw new Error('No root certificate in response');
+        logger.info(`Root CA download served`);
         res.setHeader('Content-Disposition', 'attachment; filename="caddy-root-ca.crt"');
         res.setHeader('Content-Type', 'application/x-x509-ca-cert');
         res.send(pem);
     } catch (err) {
+        logger.error(`Root CA download failed`, { error: err.message });
         res.status(404).json({ error: `Root CA cert not found: ${err.message}` });
     }
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,7 +27,7 @@ export default function App() {
     const [status, setStatus] = useState(null);
     const [sidebarOpen, setSidebarOpen] = useState(false);
     const [authEnabled, setAuthEnabled] = useState(false);
-    const [authed, setAuthed] = useState(!!getToken());
+    const [authed, setAuthed] = useState(null);
     const [sessionExpired, setSessionExpired] = useState(false);
     const [theme, setTheme] = useState(getTheme);
     const toast = useToast();
@@ -48,7 +48,7 @@ export default function App() {
     useEffect(() => {
         fetch(`${API}/auth/status`)
             .then(r => r.json())
-            .then(d => { setAuthEnabled(d.authEnabled); if (!d.authEnabled) setAuthed(true); })
+            .then(d => { setAuthEnabled(d.authEnabled); setAuthed(!d.authEnabled || !!getToken()); })
             .catch(() => setAuthed(true));
     }, []);
 
@@ -72,7 +72,7 @@ export default function App() {
     return (
         <>
             <style>{css}</style>
-            {!authed ? (
+            {authed === null ? null : !authed ? (
                 <Login onLogin={() => { setAuthed(true); setSessionExpired(false); }} sessionExpired={sessionExpired} />
             ) : (
                 <div className="shell">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import Sidebar from "./components/Sidebar.jsx";
 import TLS from "./components/TLS.jsx";
 import { Toasts, useToast } from "./components/Toasts.jsx";
 import { css } from "./styles.js";
-import { API, apiFetch, getTheme, getToken, saveTheme, setToken } from "./utils/api.js";
+import { API, apiFetch, getAuthEnabled, getTheme, getToken, saveTheme, setAuthEnabled, setToken } from "./utils/api.js";
 
 const TITLES = {
     "/dashboard": "Dashboard",
@@ -26,8 +26,9 @@ export default function App() {
     const navigate = useNavigate();
     const [status, setStatus] = useState(null);
     const [sidebarOpen, setSidebarOpen] = useState(false);
-    const [authEnabled, setAuthEnabled] = useState(false);
-    const [authed, setAuthed] = useState(null);
+    const [authEnabled, setAuthEnabledState] = useState(false);
+    const cachedAuth = getAuthEnabled();
+    const [authed, setAuthed] = useState(cachedAuth === null ? null : !cachedAuth || !!getToken());
     const [sessionExpired, setSessionExpired] = useState(false);
     const [theme, setTheme] = useState(getTheme);
     const toast = useToast();
@@ -48,7 +49,11 @@ export default function App() {
     useEffect(() => {
         fetch(`${API}/auth/status`)
             .then(r => r.json())
-            .then(d => { setAuthEnabled(d.authEnabled); setAuthed(!d.authEnabled || !!getToken()); })
+            .then(d => {
+                setAuthEnabled(d.authEnabled);
+                setAuthEnabledState(d.authEnabled);
+                setAuthed(!d.authEnabled || !!getToken());
+            })
             .catch(() => setAuthed(true));
     }, []);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,8 +27,11 @@ export default function App() {
     const [status, setStatus] = useState(null);
     const [sidebarOpen, setSidebarOpen] = useState(false);
     const [authEnabled, setAuthEnabledState] = useState(false);
-    const cachedAuth = getAuthEnabled();
-    const [authed, setAuthed] = useState(cachedAuth === null ? null : !cachedAuth || !!getToken());
+    const [authed, setAuthed] = useState(() => {
+        const cached = getAuthEnabled();
+        if (cached === null) return null;
+        return !cached || !!getToken();
+    });
     const [sessionExpired, setSessionExpired] = useState(false);
     const [theme, setTheme] = useState(getTheme);
     const toast = useToast();

--- a/frontend/src/components/CaddyFile.jsx
+++ b/frontend/src/components/CaddyFile.jsx
@@ -148,7 +148,8 @@ export default function CaddyFile({ toast, onUnauth, theme }) {
     const validate = async () => {
         setValidating(true);
         try {
-            const result = await apiFetch("/caddyfile/validations", { method: "POST", headers: { "Content-Type": "text/plain" }, body: content }, onUnauth);
+            const result = await apiFetch(`/caddyfile/validations?fmt=${runFmt}`, { method: "POST", headers: { "Content-Type": "text/plain" }, body: content }, onUnauth);
+            if (result.formatted) setContent(result.formatted);
             if (result.warnings?.length) result.warnings.forEach(w => toast.info(w));
             else toast.success("Caddyfile is valid");
         } catch (e) { toast.error(e.message); }

--- a/frontend/src/components/TLS.jsx
+++ b/frontend/src/components/TLS.jsx
@@ -16,7 +16,7 @@ export default function TLS({ toast, onUnauth }) {
     useEffect(load, []);
 
     const deleteCert = async (cert) => {
-        if (!confirm(`Delete orphaned cert for ${cert.domain}?`)) return;
+        if (!confirm(`Delete ${cert.status} cert for ${cert.domain}?`)) return;
         try {
             await apiFetch(`/tls/${cert.domain}`, { method: "DELETE" }, onUnauth);
             toast.success(`Deleted cert for ${cert.domain}`); load();
@@ -29,14 +29,17 @@ export default function TLS({ toast, onUnauth }) {
     };
 
     const summary = {
-        total: certs.filter(c => c.status !== 'orphaned').length,
+        total: certs.filter(c => c.status !== 'orphaned' && c.status !== 'superseded').length,
         valid: certs.filter(c => c.status === 'valid').length,
         expiring: certs.filter(c => c.status === 'expiring').length,
         expired: certs.filter(c => c.status === 'expired').length,
         orphaned: certs.filter(c => c.status === 'orphaned').length,
+        superseded: certs.filter(c => c.status === 'superseded').length,
     };
 
-    const filtered = filter === "all" ? certs.filter(c => c.status !== 'orphaned') : certs.filter(c => c.status === filter);
+    const filtered = filter === "all"
+        ? certs.filter(c => c.status !== 'orphaned' && c.status !== 'superseded')
+        : certs.filter(c => c.status === filter);
 
     const handleSort = (col) => {
         if (sortCol === col) setSortDir(d => d === "asc" ? "desc" : "asc");
@@ -58,6 +61,7 @@ export default function TLS({ toast, onUnauth }) {
         if (cert.status === 'expired') return <span className="badge badge-red">EXPIRED</span>;
         if (cert.status === 'expiring') return <span className="badge badge-yellow">EXPIRING</span>;
         if (cert.status === 'orphaned') return <span className="badge badge-muted">ORPHANED</span>;
+        if (cert.status === 'superseded') return <span className="badge badge-yellow">SUPERSEDED</span>;
         return <span className="badge badge-green">VALID</span>;
     };
 
@@ -72,6 +76,9 @@ export default function TLS({ toast, onUnauth }) {
         try { return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }); }
         catch { return dateStr; }
     };
+
+    const isDeletable = (cert) =>
+        cert.status === 'orphaned' || cert.status === 'superseded' || cert.status === 'expired';
 
     const filterCards = [
         { key: "all", label: "Total", val: summary.total, sub: "Managed certs", color: null },
@@ -140,12 +147,21 @@ export default function TLS({ toast, onUnauth }) {
                                 {summary.orphaned} orphaned
                             </span>
                         )}
+                        {summary.superseded > 0 && (
+                            <span
+                                className="section-label"
+                                style={{ color: filter === "superseded" ? "var(--accent)" : "var(--warn)", cursor: "pointer" }}
+                                onClick={() => setFilter(filter === "superseded" ? "all" : "superseded")}
+                            >
+                                {summary.superseded} superseded
+                            </span>
+                        )}
                         <button className="btn btn-ghost btn--sm" onClick={load}>↺ Refresh</button>
                     </div>
                 </div>
                 {sorted.length === 0 ? (
                     <div className="card-empty">
-                        {filter === "orphaned" ? "No orphaned certificates" : "No certificates in this category"}
+                        {filter === "orphaned" ? "No orphaned certificates" : filter === "superseded" ? "No superseded certificates" : "No certificates in this category"}
                     </div>
                 ) : (
                     <div className="table-wrap">
@@ -162,7 +178,7 @@ export default function TLS({ toast, onUnauth }) {
                             </thead>
                             <tbody>
                                 {sorted.map((cert, i) => (
-                                    <tr key={i} style={{ opacity: cert.status === 'orphaned' ? 0.6 : 1 }}>
+                                    <tr key={i} style={{ opacity: cert.status === 'orphaned' || cert.status === 'superseded' ? 0.6 : 1 }}>
                                         <td className="mono">{cert.domain}</td>
                                         <td><span className={`badge ${cert.issuer === 'acme' ? 'badge-blue' : 'badge-muted'}`}>{cert.issuer === 'acme' ? "Let's Encrypt" : "Internal"}</span></td>
                                         <td>
@@ -174,7 +190,7 @@ export default function TLS({ toast, onUnauth }) {
                                         </td>
                                         <td>{statusBadge(cert)}</td>
                                         <td className="col-actions-sm">
-                                            {cert.status === 'orphaned' && <button className="btn btn-danger btn--icon" onClick={() => deleteCert(cert)}>✕</button>}
+                                            {isDeletable(cert) && <button className="btn btn-danger btn--icon" onClick={() => deleteCert(cert)}>✕</button>}
                                         </td>
                                     </tr>
                                 ))}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -6,6 +6,12 @@ export function setToken(token) {
     else localStorage.removeItem('caddy_ui_token');
 }
 
+export function getAuthEnabled() {
+    const v = localStorage.getItem('caddy_ui_auth_enabled');
+    return v === null ? null : v === 'true';
+}
+export function setAuthEnabled(v) { localStorage.setItem('caddy_ui_auth_enabled', String(v)); }
+
 export function getTheme() { return localStorage.getItem('caddy_ui_theme') || 'dark'; }
 export function saveTheme(theme) { localStorage.setItem('caddy_ui_theme', theme); }
 


### PR DESCRIPTION
## Summary
- Fixes `caddy fmt` and `caddy version` hanging indefinitely with Caddy v2.11.3 by replacing `execAsync` with `docker exec` via a shared `docker.js` helper. Requires
`/var/run/docker.sock` mounted in the backend container and `docker-cli` installed in the image
- Adds structured logging throughout the backend (`logger.js`) with `LOG_LEVEL` env var support (`debug`/`info`/`warn`/`error`, defaults to `info`)
- Validate button now runs `caddy fmt` and updates the editor when the fmt checkbox is checked
- Fixes login screen flash on load when auth is disabled by deferring `authed` state until `/auth/status` resolves
- Adds `superseded` cert status for internal certs that have been replaced by an ACME cert, with delete support

## Compose changes required
```yaml
caddy-ui-backend:
  environment:
    - CADDY_CONTAINER_NAME=caddy  # optional, defaults to "caddy"
  volumes:
    - /var/run/docker.sock:/var/run/docker.sock
 ```